### PR TITLE
Replace technical deep-dive PDF link with the Medium article

### DIFF
--- a/docs/watt-seer-coach.md
+++ b/docs/watt-seer-coach.md
@@ -62,7 +62,7 @@ On the other hand, millions of Americans only have **paper bills** with **monthl
 Check out the Video
 [![Watch the video](https://img.youtube.com/vi/ED8UNHP2eHo/hqdefault.jpg)](https://youtu.be/ED8UNHP2eHo)
 
-Check out the PDF [technical document that dives deep into the GenAI approach of solving the problem](watt-seer-coach-technical.pdf)  
+Check out the [technical document that dives deep into the GenAI approach of solving the problem](https://medium.com/@apte.ashwini99/title-watt-seer-personalized-energy-coach-genai-approach-2ad5b54b0b05)
 
 ---
 
@@ -133,7 +133,7 @@ Gemini Vision read Jerry's scanned bill and returned:
 
 ## 💬 Technical details: Use case, GenAI capabilities and lessons learned
 
-Refer to the PDF [technical document that dives deep into the GenAI approach of solving the problem](watt-seer-coach-technical.pdf)  
+Refer to the [technical document that dives deep into the GenAI approach of solving the problem](https://medium.com/@apte.ashwini99/title-watt-seer-personalized-energy-coach-genai-approach-2ad5b54b0b05)
 
 ---
 


### PR DESCRIPTION
Ashwini revised the documentation with code from Version 16 of Suresh's Kaggle notebook & published it as a Medium article. Hence, revising the blog to replace PDF link with the Medium article outlining the GenAI capabilities used in our notebook. 